### PR TITLE
First steps to provides.py for elastic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,33 @@ def connect_to_elasticsearch(elasticsearch):
 
 If your charm needs to provide Elasticsearch connection details:
 
-- NOT IMPLEMENTED, check back later *coming soon*
+    If your charm needs to connect to ElasticSearch:
+
+      `metadata.yaml`
+
+    ```yaml
+    provides:
+      elasticsearch:
+        interface: elasticsearch
+    ```
+
+      `layer.yaml`
+
+    ```yaml
+    includes: ['interface:elasticsearch']
+    ```  
+
+      `reactive/code.py`
+
+    ```
+    @when('client.available')
+    def connect_to_client(client):
+        conf = config()
+        cluster_name = conf['cluster-name']
+        port = conf['port']
+        client.configure(port,cluster_name)
+
+    ```
 
 ### States
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ def connect_to_elasticsearch(elasticsearch):
 If your charm needs to provide Elasticsearch connection details:
 
   `metadata.yaml`
-  
+
 ```yaml
 provides:
   elasticsearch:
@@ -48,7 +48,7 @@ provides:
 ```
 
   `layer.yaml`
-  
+
 ```yaml
 includes: ['interface:elasticsearch']
 ```
@@ -56,12 +56,14 @@ includes: ['interface:elasticsearch']
   `reactive/code.py`
 
 ```python
-@when('client.available')
+@when('client.connected')
 def connect_to_client(client):
     conf = config()
     cluster_name = conf['cluster-name']
     port = conf['port']
     client.configure(port,cluster_name)
+    for c in client.list_connected_clients_data():
+        host_ip = c.get_remote_ip()
 ```
 
 ### States

--- a/interface.yaml
+++ b/interface.yaml
@@ -1,4 +1,3 @@
-﻿name: elasticsearchlocal
+﻿name: elasticsearch
 maintainer: charles.butler@canonical.com
 version: 1
-

--- a/interface.yaml
+++ b/interface.yaml
@@ -1,4 +1,4 @@
-name: elasticsearch
+﻿name: elasticsearchlocal
 maintainer: charles.butler@canonical.com
 version: 1
 

--- a/provides.py
+++ b/provides.py
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint: disable=c0111,c0103,c0301
+from charmhelpers.core import hookenv
+from charms.reactive import RelationBase
+from charms.reactive import hook
+from charms.reactive import scopes
+
+
+class ElasticSearchProvides(RelationBase):
+    # Every unit connecting will get the same information
+    scope = scopes.GLOBAL
+
+    auto_accessors = ['host', 'port']
+    # Use some template magic to declare our relation(s)
+    @hook('{provides:elasticsearch}-relation-joined')
+    def joined(self):
+        self.set_state('{relation_name}.joined')
+
+    @hook('{provides:elasticsearch}-relation-changed')
+    def changed(self):
+        self.set_state('{relation_name}.ready')
+
+    @hook('{provides:elasticsearch}-relation-departed')
+    def departed(self):
+        self.remove_state('{relation_name}.ready')
+        self.remove_state('{relation_name}.joined')
+
+    def configure(self, port, cluster_name):
+        conv = self.conversation()
+        conv.set_remote(data={
+            'port': port,
+            'cluster_name': cluster_name,
+            'host': hookenv.unit_get('private-address')
+        })

--- a/provides.py
+++ b/provides.py
@@ -22,12 +22,12 @@ class ElasticSearchProvides(RelationBase):
 
     # Use some template magic to declare our relation(s)
 
-    @hook('{provides:elasticsearchlocal}-relation-{joined,changed}')
+    @hook('{provides:elasticsearch}-relation-{joined,changed}')
     def joined(self):
         conv = self.conversation()
         conv.set_state('{relation_name}.connected')
 
-    @hook('{provides:elasticsearchlocal}-relation-{departed,broken}')
+    @hook('{provides:elasticsearch}-relation-{departed,broken}')
     def departed(self):
         conv = self.conversation()
         conv.remove_state('{relation_name}.connected')

--- a/provides.py
+++ b/provides.py
@@ -24,7 +24,7 @@ class ElasticSearchProvides(RelationBase):
     # Use some template magic to declare our relation(s)
     @hook('{provides:elasticsearch}-relation-joined')
     def joined(self):
-        self.set_state('{relation_name}.joined')
+        self.set_state('{relation_name}.available')
 
     @hook('{provides:elasticsearch}-relation-changed')
     def changed(self):

--- a/requires.py
+++ b/requires.py
@@ -9,6 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# pylint: disable=c0111,c0103,c0301
 
 from charms.reactive import RelationBase
 from charms.reactive import hook

--- a/requires.py
+++ b/requires.py
@@ -13,14 +13,16 @@
 
 from charms.reactive import RelationBase
 from charms.reactive import hook
+from charms.reactive import scopes
 
 
 class ElasticSearchClient(RelationBase):
     # Existing elasticsearch client interface listed here:
     # https://api.jujucharms.com/charmstore/v5/trusty/elasticsearch-13/archive/playbook.yaml
+    scope = scopes.UNIT
     auto_accessors = ['host', 'port']
 
-    @hook('{requires:elasticsearch}-relation-{joined,changed}')
+    @hook('{requires:elasticsearchlocal}-relation-{joined,changed}')
     def changed(self):
         self.set_state('{relation_name}.connected')
         conv = self.conversation()
@@ -28,11 +30,12 @@ class ElasticSearchClient(RelationBase):
         if conv.get_remote('port'):
             conv.set_state('{relation_name}.available')
 
-    @hook('{requires:elasticsearch}-relation-{departed}')
+    @hook('{requires:elasticsearchlocal}-relation-{departed,broken}')
     def departed(self):
-        self.remove_state('{relation_name}.connected')
-        self.remove_state('{relation_name}.available')
-        self.set_state('{relation_name}.broken')
+        conv = self.conversation()
+        conv.remove_state('{relation_name}.connected')
+        conv.remove_state('{relation_name}.available')
+        conv.set_state('{relation_name}.broken')
 
     def list_unit_data(self):
         ''' Iterate through all ElasticSearch conversations and return the data
@@ -44,5 +47,5 @@ class ElasticSearchClient(RelationBase):
         '''
         for conv in self.conversations():
             yield {'cluster_name': conv.get_remote('cluster_name'),
-                   'host': conv.get_remote('host'),
+                   'host': conv.get_remote('private-address'),
                    'port': conv.get_remote('port')}

--- a/requires.py
+++ b/requires.py
@@ -22,7 +22,7 @@ class ElasticSearchClient(RelationBase):
     scope = scopes.UNIT
     auto_accessors = ['host', 'port']
 
-    @hook('{requires:elasticsearchlocal}-relation-{joined,changed}')
+    @hook('{requires:elasticsearch}-relation-{joined,changed}')
     def changed(self):
         self.set_state('{relation_name}.connected')
         conv = self.conversation()
@@ -30,7 +30,7 @@ class ElasticSearchClient(RelationBase):
         if conv.get_remote('port'):
             conv.set_state('{relation_name}.available')
 
-    @hook('{requires:elasticsearchlocal}-relation-{departed,broken}')
+    @hook('{requires:elasticsearch}-relation-{departed,broken}')
     def departed(self):
         conv = self.conversation()
         conv.remove_state('{relation_name}.connected')


### PR DESCRIPTION
## overview

- Updated Readme for provides.py 
- added provides.py

#### provides.py
 - host, clustername and port are set
- Elasticsearch charm will have to provide these

##### Elastic Search
- currently working on a reactive layered elasticsearch(version 5.1) charm where this layer is being used to make relationships with the metricbeat charm (also in development) 