### PR TITLE
Fixed relation field reference

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -46,6 +46,6 @@ class ElasticSearchClient(RelationBase):
             print(unit['cluster_name'])
         '''
         for conv in self.conversations():
-            yield {'cluster_name': conv.get_remote('cluster_name'),
+            yield {'cluster_name': conv.get_remote('cluster-name'),
                    'host': conv.get_remote('private-address'),
                    'port': conv.get_remote('port')}


### PR DESCRIPTION
The elasticsearch charm shares the cluster name via "cluster-name"
rather than "cluster_name".

As clients already exist and expect to use the cluster_name field
returned from this function, I opted to leave that alone and only
changed the field we attempt to pull from the relation.