### PR TITLE
list_unit_data: retrieve version, if supplied

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -48,4 +48,5 @@ class ElasticSearchClient(RelationBase):
         for conv in self.conversations():
             yield {'cluster_name': conv.get_remote('cluster_name'),
                    'host': conv.get_remote('private-address'),
-                   'port': conv.get_remote('port')}
+                   'port': conv.get_remote('port'),
+                   'version': conv.get_remote('version', default=None)}


### PR DESCRIPTION
A recent change to elasticsearch-charm has added "version" as a field shared via its relations.

I'd like to be able to pull this field via this interface layer, as a charm which uses it (mongodb) needs to evaluate whether the remote version of ES is suitable for use with graylog or not.