### PR TITLE
Support pulling cluster_name via cluster-name

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -46,6 +46,11 @@ class ElasticSearchClient(RelationBase):
             print(unit['cluster_name'])
         '''
         for conv in self.conversations():
-            yield {'cluster_name': conv.get_remote('cluster_name'),
+            cluster_name = conv.get_remote('cluster_name')
+            if cluster_name is None:
+                # Some non-reactive charms providing the elasticsearch relation
+                # use cluster-name instead.
+                cluster_name = conv.get_remote('cluster-name')
+            yield {'cluster_name': cluster_name,
                    'host': conv.get_remote('private-address'),
                    'port': conv.get_remote('port')}


### PR DESCRIPTION
Some non-reactive charms which provide the elasticsearch relation use
the cluster-name field to provide the cluster name, rather than
cluster_name as this interface defines.

As charms exist in the charmstore which provide and consume via both
patterns, it makes sense to update the requires side of this interface
to fall back to cluster-name if there does not appear to be a
cluster_name field defined.